### PR TITLE
Deprecate resourceObject and use resource in tests

### DIFF
--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -10,6 +10,8 @@ abstract class JsonApiResource extends JsonResource
 {
     /**
      * The object represented in this resource
+     *
+     * @deprecated please use `resource` instead
      */
     protected mixed $resourceObject;
 
@@ -200,7 +202,8 @@ abstract class JsonApiResource extends JsonResource
             return false;
         }
 
-        if (is_subclass_of($resourceClass, JsonApiCollectionResource::class) &&
+        if (
+            is_subclass_of($resourceClass, JsonApiCollectionResource::class) &&
             $resourceData->isEmpty()
         ) {
             return false;
@@ -217,7 +220,8 @@ abstract class JsonApiResource extends JsonResource
      */
     private function convertRelationStringToReference(string $dataPath): mixed
     {
-        if (method_exists($this->resourceObject, 'relationLoaded')
+        if (
+            method_exists($this->resourceObject, 'relationLoaded')
             && $this->resourceObject->relationLoaded($dataPath) === false
         ) {
             return null;
@@ -301,7 +305,8 @@ abstract class JsonApiResource extends JsonResource
         $attributes = $this->resourceRegistrationData['attributes'];
         $type = $this->resourceRegistrationData['type'];
 
-        if (! ($fieldSet = $request->query('fields'))
+        if (
+            ! ($fieldSet = $request->query('fields'))
             || ! array_key_exists($type, $fieldSet)
             || ! ($fields = explode(',', $fieldSet[$type]))
         ) {

--- a/tests/Resources/AccountResource.php
+++ b/tests/Resources/AccountResource.php
@@ -10,10 +10,10 @@ class AccountResource extends JsonApiResource
     {
 
         $data = [
-            'id' => $this->resourceObject->identifier,
+            'id' => $this->resource->identifier,
             'type' => 'accounts',
             'attributes' => [
-                'name' => $this->resourceObject->name,
+                'name' => $this->resource->name,
             ],
             'relationships' => [
                 'posts' => ['posts', PostCollectionResource::class],
@@ -21,11 +21,11 @@ class AccountResource extends JsonApiResource
             ],
         ];
 
-        if ($this->resourceObject->email) {
-            $data['attributes']['email'] = $this->resourceObject->email;
+        if ($this->resource->email) {
+            $data['attributes']['email'] = $this->resource->email;
         }
 
-        if ($this->resourceObject->posts()->count() >= 10) {
+        if ($this->resource->posts()->count() >= 10) {
             $data['meta'] = [
                 'experienced_author' => true,
             ];

--- a/tests/Resources/CommentResource.php
+++ b/tests/Resources/CommentResource.php
@@ -9,10 +9,10 @@ class CommentResource extends JsonApiResource
     protected function register(): array
     {
         $data = [
-            'id' => $this->resourceObject->identifier,
+            'id' => $this->resource->identifier,
             'type' => 'comments',
             'attributes' => [
-                'content' => $this->resourceObject->content,
+                'content' => $this->resource->content,
             ],
             'relationships' => [
                 'post' => ['post', PostResource::class],

--- a/tests/Resources/PostResource.php
+++ b/tests/Resources/PostResource.php
@@ -9,11 +9,11 @@ class PostResource extends JsonApiResource
     protected function register(): array
     {
         $data = [
-            'id' => $this->resourceObject->identifier,
+            'id' => $this->resource->identifier,
             'type' => 'posts',
             'attributes' => [
-                'title' => $this->resourceObject->title,
-                'content' => $this->resourceObject->content,
+                'title' => $this->resource->title,
+                'content' => $this->resource->content,
             ],
             'relationships' => [
                 'author' => ['author', AccountResource::class],
@@ -21,10 +21,10 @@ class PostResource extends JsonApiResource
             ],
         ];
 
-        if ($this->resourceObject->url) {
+        if ($this->resource->url) {
             $data['links'] = [
                 'view' => [
-                    'href' => $this->resourceObject->url,
+                    'href' => $this->resource->url,
                 ],
             ];
         }


### PR DESCRIPTION
## Goal
This deprecates a redundant property from the package's `JsonApiResource` class to use a similar one from it's parent.

## CL
- Deprecate `resourceObject` in favor of `resource`
- Use `resource` in packages Test Resources