### PR TITLE
Remove resourceObject from JsonApiResource

### DIFF
--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -9,13 +9,6 @@ use Illuminate\Support\Collection;
 abstract class JsonApiResource extends JsonResource
 {
     /**
-     * The object represented in this resource
-     *
-     * @deprecated please use `resource` instead
-     */
-    protected mixed $resourceObject;
-
-    /**
      * The registered resource data
      */
     private array $resourceRegistrationData;
@@ -60,7 +53,6 @@ abstract class JsonApiResource extends JsonResource
         parent::__construct($resource);
 
         $this->resourceDepth = $resourceDepth ?? 0;
-        $this->resourceObject = $resource;
         $this->resourceRegistrationData = $this->register();
         $this->resourceKey = "{$this->resourceRegistrationData['type']}.{$this->resourceRegistrationData['id']}";
 


### PR DESCRIPTION
## Removes resourceObject from JsonApiResource

Due to the fact that we can use `resource` from Laravel's `JsonResource`. See https://github.com/brainstudnl/json-api-resource/pull/14 and https://github.com/brainstudnl/json-api-resource/pull/15 for reference.