### PR TITLE
Add custom resource metadata

### DIFF
--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -35,6 +35,16 @@ abstract class JsonApiResource extends JsonResource
      */
     public int $resourceDepth = 0;
 
+    /**
+     * Metadata for the resource
+     *
+     * NOTE: this differs from `additional` on JsonResource which adds to the response.
+     */
+    public array $meta = [];
+
+    /**
+     * The maximum amount of (sub) includes to include.
+     */
     private int $maxResourceDepth;
 
     /**
@@ -88,8 +98,8 @@ abstract class JsonApiResource extends JsonResource
             'attributes' => $this->getAttributes($request),
         ];
 
-        if (! empty($this->resourceRegistrationData['meta']) || ! empty($this->additional)) {
-            $response['meta'] = array_merge($this->resourceRegistrationData['meta'] ?? [], $this->additional);
+        if (! empty($this->resourceRegistrationData['meta']) || ! empty($this->meta)) {
+            $response['meta'] = array_merge($this->resourceRegistrationData['meta'] ?? [], $this->meta);
         }
 
         if (! empty($this->resourceRegistrationData['links'])) {
@@ -106,20 +116,20 @@ abstract class JsonApiResource extends JsonResource
     /**
      * Add metadata to the resource.
      *
-     * Saves the given data to the `$additional` property.
+     * Saves the given data to the `$meta` property.
      * Please note that this metadata overwrites any added metadata from the `register()` function.
      *
-     * @param  array  $data  An associative array to add to additional
+     * @param  array  $data  An associative array to add to the metadata
      *
      * @throws \InvalidArgumentException if a non-associative array is given to the function
      */
-    public function additional(array $data): self
+    public function addMeta(array $data): self
     {
         if (array_is_list($data)) {
             throw new \InvalidArgumentException('Metadata should be an associative array, i.e. ["key" => "value"]');
         }
 
-        $this->additional = array_merge($this->additional, $data);
+        $this->meta = array_merge($this->meta, $data);
 
         return $this;
     }

--- a/tests/Unit/JsonApiResourceTest.php
+++ b/tests/Unit/JsonApiResourceTest.php
@@ -292,16 +292,15 @@ class JsonApiResourceTest extends TestCase
 
         Route::get('test-route', fn (Request $request) => (
             AccountResource::make([Account::with(explode(',', $request->query()['includes']))->first(), 2])
-                ->additional(['added_metadata' => true])
+                ->addMeta(['added_metadata' => true])
         ));
 
         $response = $this->getJson('test-route?includes=posts');
 
-        ray($response->getContent());
         $response->assertOk();
         $response->assertJsonFragment(['added_metadata' => true]);
 
-        // The one below comes from te resource defintition (if more than 10 posts)
+        // The one below comes from the register function (if more than 10 posts)
         $response->assertJsonFragment(['experienced_author' => true]);
     }
 
@@ -309,15 +308,14 @@ class JsonApiResourceTest extends TestCase
     {
         Account::factory()->create();
 
-        Route::get('test-route', fn (Request $request) => (
-            AccountResource::make([Account::with(explode(',', $request->query()['includes']))->first(), 2])
-                ->additional(['added_metadata' => true])
-                ->additional(['extra_metadata' => true])
+        Route::get('test-route', fn () => (
+            AccountResource::make([Account::first(), 2])
+                ->addMeta(['added_metadata' => true])
+                ->addMeta(['extra_metadata' => true])
         ));
 
-        $response = $this->getJson('test-route?includes=posts');
+        $response = $this->getJson('test-route');
 
-        ray($response->getContent());
         $response->assertOk();
         $response->assertJsonFragment(['added_metadata' => true]);
         $response->assertJsonFragment(['extra_metadata' => true]);
@@ -326,11 +324,11 @@ class JsonApiResourceTest extends TestCase
     public function testAddMetadataOverwritesExistingKeys()
     {
         $author = Account::factory()->create();
-        $posts = Post::factory(10)->for($author, 'author')->create();
+        Post::factory(10)->for($author, 'author')->create();
 
-        Route::get('test-route', fn (Request $request) => (
-            AccountResource::make([Account::with(explode(',', $request->query()['includes']))->first(), 2])
-                ->additional(['experienced_author' => false])
+        Route::get('test-route', fn () => (
+            AccountResource::make([Account::first(), 2])
+                ->addMeta(['experienced_author' => false])
         ));
 
         $response = $this->getJson('test-route?includes=posts');


### PR DESCRIPTION
## Goal
This PR adds custom resource metadata. Needed because I missed the fact that in https://github.com/brainstudnl/json-api-resource/pull/13 it's added to both the resource as the response.
The idea behind additional is that it's added to the response, not the resource.

## Implementation
Add a property to store the metadata and rewrite the `additional` overwrite to `addMeta`.
