### PR TITLE
Make ContentTooLarge exception PSR-4 compliant

### DIFF
--- a/src/Exceptions/ContentTooLargeJsonApiException.php
+++ b/src/Exceptions/ContentTooLargeJsonApiException.php
@@ -2,7 +2,7 @@
 
 namespace Brainstud\JsonApi\Exceptions;
 
-class ContentTooLarge extends JsonApiHttpException
+class ContentTooLargeJsonApiException extends JsonApiHttpException
 {
     public function __construct(?string $title = 'Content too large', string $message = 'The request is too large to process.', ?\Throwable $previous = null, int $code = 0, array $headers = [])
     {


### PR DESCRIPTION
Before this PR. ContentTooLargeJsonApiException did not have the correct classname according to PSR-4 autoloading standard. This PR fixes that.