### PR TITLE
Allow empty metadata in addMeta method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 /.idea/
 /.vscode/
+/.zed/
 
 
 .phpunit.result.cache

--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -125,7 +125,7 @@ abstract class JsonApiResource extends JsonResource
      */
     public function addMeta(array $data): self
     {
-        if (array_is_list($data)) {
+        if (! empty($data) && array_is_list($data)) {
             throw new \InvalidArgumentException('Metadata should be an associative array, i.e. ["key" => "value"]');
         }
 


### PR DESCRIPTION
## Goal
Allow for empty metadata to be given. Previously, this would result in an InvalidArgumentException, since `array_is_list([])` results in `true`.