### PR TITLE
Fix faulty isEmpty() call to empty()

### DIFF
--- a/src/Exceptions/MethodNotAllowedJsonApiException.php
+++ b/src/Exceptions/MethodNotAllowedJsonApiException.php
@@ -2,13 +2,11 @@
 
 namespace Brainstud\JsonApi\Exceptions;
 
-use function PHPUnit\Framework\isEmpty;
-
 class MethodNotAllowedJsonApiException extends JsonApiHttpException
 {
     public function __construct(?string $title = 'Method not allowed', string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = [])
     {
-        $message = isEmpty($message) ?
+        $message = empty($message) ?
             __('The method :METHOD is not supported for :route.', ['METHOD' => request()->method(), 'route' => request()->path()])
             : $message;
         parent::__construct(


### PR DESCRIPTION
In `MethodNotAllowedJsonApiException`, the `$message` was checked to be empty by a faulty (phpunit) function. This PR changes that function call to the builtin `empty()` function.