### PR TITLE
Allow for empty attributes in response

### DIFF
--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -80,14 +80,18 @@ abstract class JsonApiResource extends JsonResource
     public function getResourceData($request): array
     {
         if (empty($this->data)) {
-            $this->data = array_filter([
-                'id' => $this->getId(),
-                'type' => $this->getType(),
-                'attributes' => $this->getAttributes($request),
-                'relationships' => empty($this->relationshipReferences) ? $this->resolveRelationships($request) : $this->relationshipReferences,
-                'meta' => $this->getMeta($request),
-                'links' => $this->getLinks($request),
-            ], fn ($value) => ! empty($value));
+            $this->data = array_filter(
+                [
+                    'id' => $this->getId(),
+                    'type' => $this->getType(),
+                    'attributes' => $this->getAttributes($request),
+                    'relationships' => empty($this->relationshipReferences) ? $this->resolveRelationships($request) : $this->relationshipReferences,
+                    'meta' => $this->getMeta($request),
+                    'links' => $this->getLinks($request),
+                ],
+                fn ($value, $key) => $key === 'attributes' || ! empty($value),
+                ARRAY_FILTER_USE_BOTH
+            );
         }
 
         return $this->data;


### PR DESCRIPTION
## Goal

Allow empty attributes array in responses. This is to make sure we don't break any existing functionality. The array_filter method removed attributes from the response before this change.