### PR TITLE
Type getId method as string or int

### DIFF
--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -141,7 +141,7 @@ abstract class JsonApiResource extends JsonResource
      * Default to either `registerData['id']` or an
      * `identifier` field on the resource.
      */
-    protected function getId(): string
+    protected function getId(): string|int
     {
         return $this->registerData['id'] ?? $this->resource->{$this->resource->getRouteKeyName()};
     }


### PR DESCRIPTION
## Goal

Make sure we don't break old behaviour. This change keeps the typing of `'id'` in the response the same as before. 