### PR TITLE
Apply filter to outcome of toRelationships method

### DIFF
--- a/src/Traits/Relationships.php
+++ b/src/Traits/Relationships.php
@@ -27,7 +27,7 @@ trait Relationships
     public function resolveRelationships($request): array
     {
         $this->request = $request;
-        $relationships = $this->toRelationships($request);
+        $relationships = $this->filter($this->toRelationships($request));
 
         if ($this->resourceDepth < $this->maxResourceDepth) {
             $this->mapRelationships($relationships);


### PR DESCRIPTION
## Goal

Previously, it was thought that filtering the outcomes of the `toRelationships` method wasn't necessary. While implementing v4.1.0 into our codebase, I found that it in fact **is** needed. This is due to the fact that we might use `mergeWhen()` or `when` while defining our relationships, which may result in a `Illuminate\Http\Resources\MissingValue`.