### PR TITLE
Add more robust id resolving

### DIFF
--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 abstract class JsonApiResource extends JsonResource
 {
     use Traits\Attributes;
+    use Traits\Id;
     use Traits\Links;
     use Traits\Meta;
     use Traits\Relationships;
@@ -140,14 +141,15 @@ abstract class JsonApiResource extends JsonResource
     }
 
     /**
-     * Get the id of the resource.
+     * Define the `id` for the resource.
      *
-     * Default to either `registerData['id']` or an
-     * `identifier` field on the resource.
+     * If this method is not overwritten, the package will try to guess the
+     * `id` by (in order) the `id` in `registerData`, calling the Eloquent
+     * method `getRouteKeyName`, an `id` property or return `null`.
      */
-    protected function getId(): string|int
+    protected function toId(): string|int|null
     {
-        return $this->registerData['id'] ?? $this->resource->{$this->resource->getRouteKeyName()};
+        return null;
     }
 
     /**

--- a/src/Traits/Id.php
+++ b/src/Traits/Id.php
@@ -21,13 +21,13 @@ trait Id
      */
     private function guessId(): int|string|null
     {
-        return $this->fromRegisterData()
+        return $this->idFromRegisterData()
             ?? $this->fromRouteKey()
             ?? $this->fromIdAttribute()
             ?? null;
     }
 
-    private function fromRegisterData(): int|string|null
+    private function idFromRegisterData(): int|string|null
     {
         return $this->registerData['id'] ?? null;
     }

--- a/src/Traits/Id.php
+++ b/src/Traits/Id.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Brainstud\JsonApi\Traits;
+
+trait Id
+{
+    private function getId(): int|string|null
+    {
+        return $this->toId() ?? $this->guessId();
+    }
+
+    /**
+     * Try and guess the id for the resource.
+     *
+     * This method tries to guess the id for the resource. It does so by first
+     * trying the `id` field on the `registrationData`. Then, it checks if
+     * the method `getRouteKeyBinding` exists on the resource, if so, it
+     * uses that method to retrieve the identifier. If not, it tries to
+     * just use the `id` property on the resource and returns `null`
+     * otherwise.
+     */
+    private function guessId(): int|string|null
+    {
+        return $this->fromRegisterData()
+            ?? $this->fromRouteKey()
+            ?? $this->fromIdAttribute()
+            ?? null;
+    }
+
+    private function fromRegisterData(): int|string|null
+    {
+        return $this->registerData['id'] ?? null;
+    }
+
+    private function fromRouteKey(): int|string|null
+    {
+        return method_exists($this->resource, 'getRouteKeyName')
+            ? $this->resource->{$this->resource->getRouteKeyName()}
+            : null;
+    }
+
+    private function fromIdAttribute(): int|string|null
+    {
+        return property_exists($this->resource, 'id')
+            ? $this->resource->id
+            : null;
+    }
+}

--- a/tests/Models/Intern.php
+++ b/tests/Models/Intern.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Brainstud\JsonApi\Tests\Models;
+
+class Intern
+{
+    public int $id;
+
+    public string $name;
+
+    public string $department;
+
+    public function __construct(string $name, string $department)
+    {
+        $this->id = random_int(0, 100);
+        $this->name = $name;
+        $this->department = $department;
+    }
+}

--- a/tests/Resources/DeveloperToIdResource.php
+++ b/tests/Resources/DeveloperToIdResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Brainstud\JsonApi\Tests\Resources;
+
+use Brainstud\JsonApi\Tests\Models\Developer;
+
+/**
+ * @property Developer $resource
+ */
+class DeveloperToIdResource extends DeveloperResource
+{
+    protected function toId(): string|int|null
+    {
+        return $this->resource->name;
+    }
+}

--- a/tests/Resources/InternResource.php
+++ b/tests/Resources/InternResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Brainstud\JsonApi\Tests\Resources;
+
+use Brainstud\JsonApi\Resources\JsonApiResource;
+use Brainstud\JsonApi\Tests\Models\Intern;
+use Illuminate\Http\Request;
+
+/**
+ * @property Intern $resource
+ */
+class InternResource extends JsonApiResource
+{
+    protected string $type = 'interns';
+
+    protected function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->resource->name,
+            'department' => $this->resource->department,
+        ];
+    }
+}

--- a/tests/Unit/JsonApiResourceTest.php
+++ b/tests/Unit/JsonApiResourceTest.php
@@ -3,10 +3,11 @@
 namespace Brainstud\JsonApi\Tests\Unit;
 
 use Brainstud\JsonApi\Tests\Models\Developer;
+use Brainstud\JsonApi\Tests\Models\Intern;
 use Brainstud\JsonApi\Tests\Models\PullRequest;
 use Brainstud\JsonApi\Tests\Models\Review;
 use Brainstud\JsonApi\Tests\Resources\DeveloperResource;
-use Brainstud\JsonApi\Tests\Resources\DeveloperToIdResource;
+use Brainstud\JsonApi\Tests\Resources\InternResource;
 use Brainstud\JsonApi\Tests\Resources\PullRequestResource;
 use Brainstud\JsonApi\Tests\TestCase;
 use Illuminate\Http\Request;
@@ -24,14 +25,14 @@ class JsonApiResourceTest extends TestCase
         $response->assertExactJson(['data' => $this->createJsonResource($developer)]);
     }
 
-    public function testWithCustomToIdMethod()
+    public function testNonEloquentResource()
     {
-        $developer = Developer::factory()->create();
+        $intern = new Intern('Markie Mark', 'Development');
 
-        Route::get('test-route', fn () => DeveloperToIdResource::make($developer));
+        Route::get('test-route', fn () => InternResource::make($intern));
         $response = $this->getJson('test-route');
 
-        $response->assertJsonFragment(['id' => $developer->name]);
+        $response->assertJsonFragment(['id' => $intern->id]);
     }
 
     public function testBasicResourceCollection()

--- a/tests/Unit/JsonApiResourceTest.php
+++ b/tests/Unit/JsonApiResourceTest.php
@@ -6,6 +6,7 @@ use Brainstud\JsonApi\Tests\Models\Developer;
 use Brainstud\JsonApi\Tests\Models\PullRequest;
 use Brainstud\JsonApi\Tests\Models\Review;
 use Brainstud\JsonApi\Tests\Resources\DeveloperResource;
+use Brainstud\JsonApi\Tests\Resources\DeveloperToIdResource;
 use Brainstud\JsonApi\Tests\Resources\PullRequestResource;
 use Brainstud\JsonApi\Tests\TestCase;
 use Illuminate\Http\Request;
@@ -21,6 +22,16 @@ class JsonApiResourceTest extends TestCase
         $response = $this->getJson('test-route');
 
         $response->assertExactJson(['data' => $this->createJsonResource($developer)]);
+    }
+
+    public function testWithCustomToIdMethod()
+    {
+        $developer = Developer::factory()->create();
+
+        Route::get('test-route', fn () => DeveloperToIdResource::make($developer));
+        $response = $this->getJson('test-route');
+
+        $response->assertJsonFragment(['id' => $developer->name]);
     }
 
     public function testBasicResourceCollection()


### PR DESCRIPTION
## Goal
This MR implements more robust id resolving for the package. It does so by adding a new `Id` trait and a `toId()` method. The trait consists primarily of a main `getId()` method that tries to - well - get the id 🤷🏽. It does so by:
1. Returning the result of the `toId` method, if any.
2. Check if there is an id in the `registerData` property.
3. Check if the method `getRouteKeyName` exists on the resource, and returns the result if it does.
4. Check if there is a property `id` defined on the resource, and returns the result if it does.
5. Return `null`