### PR TITLE
Handle null resource more gracefully in toId

### DIFF
--- a/src/Traits/Id.php
+++ b/src/Traits/Id.php
@@ -6,6 +6,10 @@ trait Id
 {
     private function getId(): int|string|null
     {
+        if ($this->resource === null) {
+            return null;
+        }
+
         return $this->toId() ?? $this->guessId();
     }
 

--- a/tests/Unit/JsonApiResourceTest.php
+++ b/tests/Unit/JsonApiResourceTest.php
@@ -35,6 +35,14 @@ class JsonApiResourceTest extends TestCase
         $response->assertJsonFragment(['id' => $intern->id]);
     }
 
+    public function test_null_resource_handled_gracefully()
+    {
+        Route::get('test-route', fn () => new InternResource(null));
+        $response = $this->getJson('test-route');
+
+        $response->assertJson(['data' => []]);
+    }
+
     public function test_basic_resource_collection()
     {
         $developers = Developer::factory()->count(3)->create();


### PR DESCRIPTION
  ## Summary
  Fixes a bug where passing `null` to a JsonApiResource would cause errors when trying to access properties during ID resolution.

  ## Changes
  - Added null check in `getId()` to return `null` early when resource is null
  - Added test case to verify null resources return empty data arrays