### PR TITLE
Add matrix strategy to test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,45 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*]
+        include:
+          - laravel: 10.*
+            testbench: ^8.0
+            phpunit: ^10.0
+          - laravel: 11.*
+            testbench: ^9.0
+            phpunit: ^10.5
+          - laravel: 12.*
+            testbench: ^10.0
+            phpunit: ^11.0
+        exclude:
+          # Laravel 10 doesn't support PHP 8.4
+          - php: 8.4
+            laravel: 10.*
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
     steps:
       - uses: actions/checkout@v3
 
-      - uses: php-actions/composer@v6
-
-      - name: PHPUnit Tests
-        uses: php-actions/phpunit@master
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          version: 9.6
-          bootstrap: vendor/autoload.php
-          configuration: ./phpunit.xml
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [10.*, 11.*, 12.*]
         include:
           - laravel: 10.*
@@ -29,6 +29,11 @@ jobs:
           # Laravel 10 doesn't support PHP 8.4
           - php: 8.4
             laravel: 10.*
+          # Only Laravel 12 supports PHP 8.5
+          - php: 8.5
+            laravel: 10.*
+          - php: 8.5
+            laravel: 11.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -44,7 +49,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --dev --no-interaction --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -75,6 +75,12 @@ abstract class JsonApiResource extends JsonResource
             : $this->addToResponse($request, $this->getResourceData($request));
     }
 
+    /**
+     * Resolve the resource data to an array.
+     *
+     * Override Laravel 12's implementation to prevent circular dependency
+     * between toArray() and toAttributes().
+     */
     public function resolveResourceData($request): array
     {
         return is_null($this->resource)

--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -172,7 +172,7 @@ abstract class JsonApiResource extends JsonResource
      * Default to either `registerData['attributes']` or an empty array.
      * Should be overwritten to create custom attributes.
      */
-    protected function toAttributes(Request $request): array
+    public function toAttributes(Request $request): array
     {
         return $this->registerData['attributes'] ?? [];
     }

--- a/src/Resources/JsonApiResource.php
+++ b/src/Resources/JsonApiResource.php
@@ -75,6 +75,13 @@ abstract class JsonApiResource extends JsonResource
             : $this->addToResponse($request, $this->getResourceData($request));
     }
 
+    public function resolveResourceData($request): array
+    {
+        return is_null($this->resource)
+            ? []
+            : $this->addToResponse($request, $this->getResourceData($request));
+    }
+
     /**
      * Returns the value of $this->data and sets it if it's empty.
      */

--- a/tests/Resources/DeveloperResource.php
+++ b/tests/Resources/DeveloperResource.php
@@ -9,7 +9,7 @@ class DeveloperResource extends JsonApiResource
 {
     protected string $type = 'developers';
 
-    protected function toAttributes(Request $request): array
+    public function toAttributes(Request $request): array
     {
         return [
             'name' => $this->resource->name,

--- a/tests/Resources/InternResource.php
+++ b/tests/Resources/InternResource.php
@@ -13,7 +13,7 @@ class InternResource extends JsonApiResource
 {
     protected string $type = 'interns';
 
-    protected function toAttributes(Request $request): array
+    public function toAttributes(Request $request): array
     {
         return [
             'name' => $this->resource->name,

--- a/tests/Resources/PullRequestResource.php
+++ b/tests/Resources/PullRequestResource.php
@@ -9,7 +9,7 @@ class PullRequestResource extends JsonApiResource
 {
     protected string $type = 'pull_requests';
 
-    protected function toAttributes(Request $request): array
+    public function toAttributes(Request $request): array
     {
         return [
             'title' => $this->resource->title,

--- a/tests/Resources/ReviewResource.php
+++ b/tests/Resources/ReviewResource.php
@@ -9,7 +9,7 @@ class ReviewResource extends JsonApiResource
 {
     protected string $type = 'reviews';
 
-    protected function toAttributes(Request $request): array
+    public function toAttributes(Request $request): array
     {
         return [
             'content' => $this->resource->content,


### PR DESCRIPTION
Currently the package supports multiple versions of php and laravel, but not all versions work together correctly.

The matrix strategy tries to make sure all combinations keep working